### PR TITLE
Remove SaaS & Apps section from projects page

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -18,10 +18,6 @@ const projects = {
     { name: 'Gru', url: 'https://github.com/agorapulse/gru', description: 'HTTP interaction testing framework for Micronaut & Spring', stars: null, updated: '2025' },
     { name: 'Fixt', url: 'https://github.com/agorapulse/fixt', description: 'Organize test fixtures in directories matching your test classes', stars: null, updated: null },
   ],
-  saasApps: [
-    { name: 'SheetRest', url: 'https://sheetrest.com', description: 'Turn Google Sheets into REST APIs instantly', stars: null, updated: '2025' },
-    { name: 'Spreadsheet Builder', url: 'https://github.com/dsl-builders/spreadsheet', description: 'Create Excel spreadsheets with Groovy DSL or Java builders', stars: 25, updated: '2024' },
-  ],
   dslBuilders: [
     { name: 'expectations', org: 'dsl-builders', url: 'https://github.com/dsl-builders/expectations', description: 'Expectations DSL builder for expressive assertions', stars: 2, updated: '2025' },
     { name: 'groovy-closure-support', org: 'dsl-builders', url: 'https://github.com/dsl-builders/groovy-closure-support', description: 'Groovy closure support for Java DSL builders', stars: 2, updated: '2023' },
@@ -58,24 +54,6 @@ const projects = {
       <h2>Testing Libraries</h2>
       <div class="project-grid">
         {projects.testing.map((project) => (
-          <article class="project-card">
-            <h3>
-              <a href={project.url} target="_blank" rel="noopener">{project.name}</a>
-            </h3>
-            <p>{project.description}</p>
-            <div class="card-meta">
-              {project.stars && <span class="stars">⭐ {project.stars}</span>}
-              {project.updated && <span class="updated">Updated {project.updated}</span>}
-            </div>
-          </article>
-        ))}
-      </div>
-    </section>
-
-    <section class="project-section">
-      <h2>SaaS & Apps</h2>
-      <div class="project-grid">
-        {projects.saasApps.map((project) => (
           <article class="project-card">
             <h3>
               <a href={project.url} target="_blank" rel="noopener">{project.name}</a>


### PR DESCRIPTION
Removes the SaaS & Apps block (SheetRest and Spreadsheet Builder) from /projects.